### PR TITLE
Bug fixes for command aliases

### DIFF
--- a/src/main/java/com/atherys/chat/command/ChannelAliasCommand.java
+++ b/src/main/java/com/atherys/chat/command/ChannelAliasCommand.java
@@ -33,7 +33,7 @@ public class ChannelAliasCommand implements PlayerCommand, CommandExecutor {
         if (args.getOne("message").isPresent()) {
             AtherysChat.getInstance().getChannelFacade().speakToChannel(player, channel, args.<String>getOne("message").get());
         } else {
-            AtherysChat.getInstance().getChannelFacade().setSpeakingChannel(player, channel);
+            AtherysChat.getInstance().getChannelFacade().joinChannel(player, channel);
         }
         return CommandResult.success();
     }

--- a/src/main/java/com/atherys/chat/command/JoinChannelCommand.java
+++ b/src/main/java/com/atherys/chat/command/JoinChannelCommand.java
@@ -30,7 +30,7 @@ public class JoinChannelCommand implements PlayerCommand, ParameterizedCommand {
     @Override
     public CommandElement[] getArguments() {
         return new CommandElement[]{
-                new ChannelCommandElement(Text.of("channel"), true, false)
+                new ChannelCommandElement(Text.of("channel"))
         };
     }
 }

--- a/src/main/java/com/atherys/chat/command/LeaveChannelCommand.java
+++ b/src/main/java/com/atherys/chat/command/LeaveChannelCommand.java
@@ -30,7 +30,7 @@ public class LeaveChannelCommand implements PlayerCommand, ParameterizedCommand 
     @Override
     public CommandElement[] getArguments() {
         return new CommandElement[]{
-                new ChannelCommandElement(Text.of("channel"), false, true)
+                new ChannelCommandElement(Text.of("channel"), true, false)
         };
     }
 }

--- a/src/main/java/com/atherys/chat/config/ChannelConfig.java
+++ b/src/main/java/com/atherys/chat/config/ChannelConfig.java
@@ -42,7 +42,7 @@ public class ChannelConfig {
     public String suffix;
 
     @Setting("aliases")
-    public Set<String> aliases;
+    public Set<String> aliases = new HashSet<>();
 
     @Setting("range")
     public int range;

--- a/src/main/java/com/atherys/chat/facade/ChannelFacade.java
+++ b/src/main/java/com/atherys/chat/facade/ChannelFacade.java
@@ -110,11 +110,6 @@ public class ChannelFacade {
         channel.send(player, Text.of(message));
     }
 
-    public void setSpeakingChannel(Player player, AtherysChannel channel) {
-        chatService.setPlayerSpeakingChannel(player, channel);
-        cmf.info(player, "You are now speaking in ", channel.getTextName(), ".");
-    }
-
     public void displayPlayerChannels(Player player) {
         Text.Builder builder;
 


### PR DESCRIPTION
- Alias commands did not correct check permissions when switching channels
- Aliases defaulted to null, now default to an empty set
- Join/leave auto-completions were around the wrong way